### PR TITLE
Case sensitivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ the command line.  The format is one switch and option per line:
 -host 1.2.3.4
 ```
 
+### Case sensitivity
+
+Keyspace, table, column identifiers are case insensitive in Apache Cassandra. Anyways the
+`schema` parameter is treated internally as case sensitive and the queries used to load/unload
+data are quoting all identifiers to preserve the case sensitivity.
+
 ## Usage Statement:
 ```
 Usage: -f <filename> -host <ipaddress> -schema <schema> [OPTIONS]

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.datastax.cassandra:cassandra-driver-core:2.1.6'
+    compile 'com.datastax.cassandra:cassandra-driver-core:3.0.0'
     compile 'org.xerial.snappy:snappy-java:1.0.5'
     compile 'net.jpountz.lz4:lz4:1.2.0'
 }

--- a/src/main/java/com/datastax/loader/CqlDelimLoad.java
+++ b/src/main/java/com/datastax/loader/CqlDelimLoad.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.loader;
 
+import com.datastax.driver.core.JdkSSLOptions;
 import com.datastax.loader.parser.BooleanParser;
 import com.datastax.loader.futures.FutureManager;
 import com.datastax.loader.futures.PrintingFutureSet;
@@ -419,11 +420,10 @@ public class CqlDelimLoad {
     private SSLOptions createSSLContext() 
 	throws KeyStoreException, FileNotFoundException, IOException, NoSuchAlgorithmException, 
 	       KeyManagementException, CertificateException, UnrecoverableKeyException {
-	TrustManagerFactory tmf = null;
 	KeyStore tks = KeyStore.getInstance("JKS");
 	tks.load((InputStream) new FileInputStream(new File(truststorePath)), 
 		truststorePwd.toCharArray());
-	tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+	TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
 	tmf.init(tks);
     
 	KeyManagerFactory kmf = null;
@@ -440,7 +440,7 @@ public class CqlDelimLoad {
 			tmf != null ? tmf.getTrustManagers() : null, 
 			new SecureRandom());
 
-	return new SSLOptions(sslContext, SSLOptions.DEFAULT_SSL_CIPHER_SUITES);
+	return JdkSSLOptions.builder().withSSLContext(sslContext).build();
     }
 
     private void setup() 
@@ -454,10 +454,10 @@ public class CqlDelimLoad {
 	    .addContactPoint(host)
 	    .withPort(port)
 	    //.withProtocolVersion(ProtocolVersion.V3) 
-	    .withProtocolVersion(ProtocolVersion.V2) // Should be V3, but issues for now....
+//	    .withProtocolVersion(ProtocolVersion.V2) // Should be V3, but issues for now....
 	    //.withCompression(ProtocolOptions.Compression.LZ4)
 	    .withPoolingOptions(pOpts)
-	    .withLoadBalancingPolicy(new TokenAwarePolicy( new DCAwareRoundRobinPolicy(), true));
+	    .withLoadBalancingPolicy(new TokenAwarePolicy( DCAwareRoundRobinPolicy.builder().build(), true));
 
 	if (null != username)
 	    clusterBuilder = clusterBuilder.withCredentials(username, password);

--- a/src/main/java/com/datastax/loader/CqlDelimUnload.java
+++ b/src/main/java/com/datastax/loader/CqlDelimUnload.java
@@ -16,6 +16,9 @@
 package com.datastax.loader;
 
 import com.datastax.driver.core.JdkSSLOptions;
+import com.datastax.driver.core.querybuilder.Clause;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.datastax.driver.core.querybuilder.Select;
 import com.datastax.loader.parser.BooleanParser;
 
 import java.lang.System;
@@ -73,6 +76,12 @@ import com.datastax.driver.core.Row;
 import com.datastax.driver.core.SSLOptions;
 import com.datastax.driver.core.policies.TokenAwarePolicy;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.gt;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.lte;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.token;
 
 
 public class CqlDelimUnload {
@@ -379,15 +388,12 @@ public class CqlDelimUnload {
 	    executor.shutdown();
 	}
 	else {
-	    BigInteger begin = null;
-	    BigInteger end = null;
-	    BigInteger delta = null;
 	    List<String> beginList = new ArrayList<String>();
 	    List<String> endList = new ArrayList<String>();
 	    if (null != beginToken) {
-		begin = new BigInteger(beginToken);
-		end = new BigInteger(endToken);
-		delta = end.subtract(begin).divide(new BigInteger(String.valueOf(numThreads)));
+		BigInteger begin = new BigInteger(beginToken);
+		BigInteger end = new BigInteger(endToken);
+		BigInteger delta = end.subtract(begin).divide(new BigInteger(String.valueOf(numThreads)));
 		for (int mype = 0; mype < numThreads; mype++) {
 		    if (mype < numThreads - 1) {
 			beginList.add(begin.add(delta.multiply(new BigInteger(String.valueOf(mype)))).toString());
@@ -498,21 +504,12 @@ public class CqlDelimUnload {
 	}
 
 	private String getPartitionKey(CqlDelimParser cdp, Session tsession) {
-	    String keyspace = cdp.getKeyspace();
-	    String table = cdp.getTable();
-	    if (keyspace.startsWith("\"") && keyspace.endsWith("\""))
-		keyspace = keyspace.replaceAll("\"", "");
-	    else
-		keyspace = keyspace.toLowerCase();
-	    if (table.startsWith("\"") && table.endsWith("\""))
-		table = table.replaceAll("\"", "");
-	    else
-		table = table.toLowerCase();
-	    String query = "SELECT column_name, component_index, type "
-		+ "FROM system.schema_columns WHERE keyspace_name = '"
-		+ keyspace + "' AND columnfamily_name = '"
-		+ table + "'";
-            List<Row> rows = tsession.execute(query).all();
+	    String keyspace = cdp.getKeyspace().replace("\"", "");
+	    String table = cdp.getTable().replace("\"", "");
+		List<Row> rows = tsession.execute(select("column_name", "component_index", "type")
+									.from("system", "schema_columns")
+									.where(eq("keyspace_name", keyspace))
+									.and(eq("columnfamily_name", table))).all();
 	    if (rows.isEmpty()) {
 		System.err.println("Can't find the keyspace/table");
 		// error
@@ -548,14 +545,13 @@ public class CqlDelimUnload {
 	    cdp = new CqlDelimParser(cqlSchema, delimiter, nullString, 
 				     dateFormatString, 
 				     boolStyle, locale, null, session, false);
-	    String select = cdp.generateSelect();
-	    String partitionKey = getPartitionKey(cdp, session);
+		Select selectStmt = cdp.generateSelectNew();
 	    if (null != beginToken) {
-		select = select + " WHERE Token(" + partitionKey + ") > " 
-		    + beginToken + " AND Token(" + partitionKey + ") <= " 
-		    + endToken;
+        String partitionKey = getPartitionKey(cdp, session);
+        selectStmt.where(gt(token(partitionKey), beginToken))
+                .and(lte(token(partitionKey), endToken));
 	    }
-	    statement = session.prepare(select);
+		statement = session.prepare(selectStmt);
 	    statement.setConsistencyLevel(consistencyLevel);
 	}
 	

--- a/src/main/java/com/datastax/loader/CqlDelimUnload.java
+++ b/src/main/java/com/datastax/loader/CqlDelimUnload.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.loader;
 
+import com.datastax.driver.core.JdkSSLOptions;
 import com.datastax.loader.parser.BooleanParser;
 
 import java.lang.System;
@@ -302,7 +303,7 @@ public class CqlDelimUnload {
                         tmf != null ? tmf.getTrustManagers() : null,
                         new SecureRandom());
 
-        return new SSLOptions(sslContext, SSLOptions.DEFAULT_SSL_CIPHER_SUITES);
+        return JdkSSLOptions.builder().withSSLContext(sslContext).build();
     }
 
     private void setup()
@@ -316,7 +317,7 @@ public class CqlDelimUnload {
 	    .addContactPoint(host)
 	    .withPort(port)
             .withPoolingOptions(pOpts)
-	    .withLoadBalancingPolicy(new TokenAwarePolicy( new DCAwareRoundRobinPolicy()));
+	    .withLoadBalancingPolicy(new TokenAwarePolicy( DCAwareRoundRobinPolicy.builder().build()));
 	if (null != username)
 	    clusterBuilder = clusterBuilder.withCredentials(username, password);
         if (null != truststorePath)

--- a/src/main/java/com/datastax/loader/CqlDelimUnloadTest.java
+++ b/src/main/java/com/datastax/loader/CqlDelimUnloadTest.java
@@ -1,0 +1,9 @@
+package com.datastax.loader;
+
+
+/**
+ * @author alex
+ * @version 1.0, 3/4/16 10:54 PM
+ */
+public class CqlDelimUnloadTest {
+}

--- a/src/main/java/com/datastax/loader/EnhancedSession.java
+++ b/src/main/java/com/datastax/loader/EnhancedSession.java
@@ -15,6 +15,8 @@
  */
 package com.datastax.loader;
 
+import java.util.Map;
+
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.CloseFuture;
@@ -52,6 +54,11 @@ public class EnhancedSession implements Session {
 	return session.execute(query, values);
     }
 
+    @Override
+    public ResultSet execute(String query, Map<String, Object> values) {
+    return session.execute(query, values);
+    }
+
     public ResultSetFuture executeAsync(Statement statement) {
 	return session.executeAsync(statement);
     }
@@ -62,6 +69,11 @@ public class EnhancedSession implements Session {
 
     public ResultSetFuture executeAsync(String query, Object... values) {
 	return session.executeAsync(query, values);
+    }
+
+    @Override
+    public ResultSetFuture executeAsync(String query, Map<String, Object> values) {
+    return session.executeAsync(query, values);
     }
 
     public Cluster getCluster() {
@@ -79,6 +91,11 @@ public class EnhancedSession implements Session {
     public EnhancedSession init() {
 	session.init();
 	return this;
+    }
+
+    @Override
+    public ListenableFuture<Session> initAsync() {
+    return session.initAsync();
     }
 
     public boolean isClosed() {


### PR DESCRIPTION
To allow for simpler format for the `-schema` parameter the identifiers passed in are treated as case sensitive (and internally all queries are doing the necessary quoting).