### PR TITLE
Bugfix: Remove deprecated flag (-delimInQuotes)

### DIFF
--- a/sample/load.sh
+++ b/sample/load.sh
@@ -1,1 +1,1 @@
-../build/cassandra-loader -f titanic.csv -host localhost -schema "titanic.survivors(id, survived, passenger_class, name, sex, age, num_siblings_spouse, num_parents_children, ticket_id, fare, cabin, port_of_embarkation)" -delimInQuotes true -boolStyle 1_0
+../build/cassandra-loader -f titanic.csv -host localhost -schema "titanic.survivors(id, survived, passenger_class, name, sex, age, num_siblings_spouse, num_parents_children, ticket_id, fare, cabin, port_of_embarkation)" -boolStyle 1_0


### PR DESCRIPTION
This sample script throws an error that this flag is invalid (using latest master branch). 
Sample runs perfectly after removing this flag.