### PR TITLE
do not consider # as comment

### DIFF
--- a/src/main/java/com/datastax/loader/CqlDelimLoad.java
+++ b/src/main/java/com/datastax/loader/CqlDelimLoad.java
@@ -127,6 +127,7 @@ public class CqlDelimLoad {
     private BooleanParser.BoolStyle boolStyle = null;
     private String dateFormatString = null;
     private String nullString = null;
+    private String commentString = null;
     private String delimiter = null;
     private int charsPerColumn = 4096;
 
@@ -146,6 +147,7 @@ public class CqlDelimLoad {
         usage.append("  -charsPerColumn <chars>            Max number of chars per column [4096]\n");
         usage.append("  -dateFormat <dateFormatString>     Date format [default for Locale.ENGLISH]\n");
         usage.append("  -nullString <nullString>           String that signifies NULL [none]\n");
+        usage.append("  -comment <commentString>           Comment symbol to use [none]\n");
         usage.append("  -skipRows <skipRows>               Number of rows to skip [0]\n");
         usage.append("  -skipCols <columnsToSkip>          Comma-separated list of columsn to skip in the input file\n");
         usage.append("  -maxRows <maxRows>                 Maximum number of rows to read (-1 means all) [-1]\n");
@@ -420,6 +422,7 @@ public class CqlDelimLoad {
         if (null != (tkey = amap.remove("-badDir")))        badDir = tkey;
         if (null != (tkey = amap.remove("-dateFormat")))    dateFormatString = tkey;
         if (null != (tkey = amap.remove("-nullString")))    nullString = tkey;
+        if (null != (tkey = amap.remove("-comment")))       commentString = tkey;
         if (null != (tkey = amap.remove("-delim")))         delimiter = tkey;
         if (null != (tkey = amap.remove("-numThreads")))    numThreads = Integer.parseInt(tkey);
         if (null != (tkey = amap.remove("-rate")))          rate = Double.parseDouble(tkey);
@@ -622,7 +625,8 @@ public class CqlDelimLoad {
             // One file/stdin to process
             executor = Executors.newSingleThreadExecutor();
             Callable<Long> worker = new CqlDelimLoadTask(cqlSchema, delimiter, 
-                                                         charsPerColumn,nullString,
+                                                         charsPerColumn, nullString,
+                                                         commentString,
                                                          dateFormatString, 
                                                          boolStyle, locale, 
                                                          maxErrors, skipRows,
@@ -646,6 +650,7 @@ public class CqlDelimLoad {
                 File tFile = fileList.pop();
                 Callable<Long> worker = new CqlDelimLoadTask(cqlSchema, delimiter,
                                                              charsPerColumn, nullString,
+                                                             commentString,
                                                              dateFormatString, 
                                                              boolStyle, locale, 
                                                              maxErrors, skipRows,

--- a/src/main/java/com/datastax/loader/CqlDelimLoadTask.java
+++ b/src/main/java/com/datastax/loader/CqlDelimLoadTask.java
@@ -85,6 +85,7 @@ class CqlDelimLoadTask implements Callable<Long> {
     private BooleanParser.BoolStyle boolStyle = null;
     private String dateFormatString = null;
     private String nullString = null;
+    private String commentString = null;
     private String delimiter = null;
     private int charsPerColumn = 4096;
     private TimeUnit unit = TimeUnit.SECONDS;
@@ -100,7 +101,7 @@ class CqlDelimLoadTask implements Callable<Long> {
 
     public CqlDelimLoadTask(String inCqlSchema, String inDelimiter, 
                             int inCharsPerColumn,
-                            String inNullString, String inDateFormatString,
+                            String inNullString, String inCommentString, String inDateFormatString,
                             BooleanParser.BoolStyle inBoolStyle, 
                             Locale inLocale, 
                             long inMaxErrors, long inSkipRows, 
@@ -117,6 +118,7 @@ class CqlDelimLoadTask implements Callable<Long> {
         delimiter = inDelimiter;
         charsPerColumn = inCharsPerColumn;
         nullString = inNullString;
+        commentString = inCommentString;
         dateFormatString = inDateFormatString;
         boolStyle = inBoolStyle;
         locale = inLocale;
@@ -181,14 +183,14 @@ class CqlDelimLoadTask implements Callable<Long> {
 
         if (format.equalsIgnoreCase("delim")) {
             cdp = new CqlDelimParser(cqlSchema, delimiter, charsPerColumn, 
-                                     nullString,
+                                     nullString, commentString,
                                      dateFormatString, boolStyle, locale,
                                      skipCols, session, true);
         }
         else if (format.equalsIgnoreCase("jsonline")
                  || format.equalsIgnoreCase("jsonarray")) {
             cdp = new CqlDelimParser(keyspace, table, delimiter, charsPerColumn,
-                                     nullString, 
+                                     nullString, commentString,
                                      dateFormatString, boolStyle, locale, 
                                      skipCols, session, true);
         }

--- a/src/main/java/com/datastax/loader/CqlDelimParser.java
+++ b/src/main/java/com/datastax/loader/CqlDelimParser.java
@@ -52,7 +52,7 @@ import java.util.regex.Pattern;
 
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
-  
+
 public class CqlDelimParser {
     private Map<DataType.Name, Parser> pmap;
     private List<SchemaBits> sbl;
@@ -63,19 +63,19 @@ public class CqlDelimParser {
     private JSONParser jsonParser;
 
     public CqlDelimParser(String inCqlSchema, String inDelimiter, int inCharsPerColumn,
-                          String inNullString, String inDateFormatString, 
+                          String inNullString, String inCommentString, String inDateFormatString,
                           BooleanParser.BoolStyle inBoolStyle, Locale inLocale,
                           String skipList, Session session, boolean bLoader) 
         throws ParseException {
         // Optionally provide things for the line parser - date format, boolean format, locale
         initPmap(inDateFormatString, inBoolStyle, inLocale, bLoader);
         processCqlSchema(inCqlSchema, session);
-        createDelimParser(inDelimiter, inCharsPerColumn, inNullString, skipList);
+        createDelimParser(inDelimiter, inCharsPerColumn, inNullString, inCommentString, skipList);
     }   
 
     public CqlDelimParser(String inKeyspace, String inTable, String inDelimiter,
                           int inCharsPerColumn,
-                          String inNullString, String inDateFormatString, 
+                          String inNullString, String inCommentString, String inDateFormatString,
                           BooleanParser.BoolStyle inBoolStyle, Locale inLocale,
                           String skipList, Session session, boolean bLoader) 
         throws ParseException {
@@ -84,7 +84,7 @@ public class CqlDelimParser {
         tablename = inTable;
         initPmap(inDateFormatString, inBoolStyle, inLocale, bLoader);
         processCqlSchema(session);
-        createDelimParser(inDelimiter, inCharsPerColumn, inNullString, skipList);
+        createDelimParser(inDelimiter, inCharsPerColumn, inNullString, inCommentString,  skipList);
     }
 
     public List<String> getColumnNames() {
@@ -243,9 +243,9 @@ public class CqlDelimParser {
 
     // Creates the DelimParser that will parse the line
     private void createDelimParser(String delimiter, int charsPerColumn,
-                                   String nullString, 
+                                   String nullString, String commentString,
                                    String skipList) throws NumberFormatException {
-        delimParser = new DelimParser(delimiter, charsPerColumn, nullString);
+        delimParser = new DelimParser(delimiter, charsPerColumn, nullString, commentString);
         for (int i = 0; i < sbl.size(); i++)
             delimParser.add(sbl.get(i).parser);
         if (null != skipList) {

--- a/src/main/java/com/datastax/loader/parser/DelimParser.java
+++ b/src/main/java/com/datastax/loader/parser/DelimParser.java
@@ -35,12 +35,14 @@ public class DelimParser {
     private char delim;
     private char quote;
     private char escape;
+    private char comment;
     private List<Boolean> skip;
 
     private CsvParser csvp = null;
 
     public static String DEFAULT_DELIMITER = ",";
     public static String DEFAULT_NULLSTRING = "";
+    public static String DEFAULT_COMMENT_STRING = "\0";
     public static int DEFAULT_CHARSPERCOLUMN = 4096;
 
     public DelimParser() {
@@ -48,11 +50,11 @@ public class DelimParser {
     }
 
     public DelimParser(String inDelimiter) {
-        this(inDelimiter, DEFAULT_CHARSPERCOLUMN, DEFAULT_NULLSTRING);
+        this(inDelimiter, DEFAULT_CHARSPERCOLUMN, DEFAULT_NULLSTRING, DEFAULT_COMMENT_STRING);
     }
 
     public DelimParser(String inDelimiter, int inCharsPerColumn,
-                       String inNullString) {
+                       String inNullString, String inComment) {
         parsers = new ArrayList<Parser>();
         elements = new ArrayList<Object>();
         skip = new ArrayList<Boolean>();
@@ -65,6 +67,10 @@ public class DelimParser {
             nullString = DEFAULT_NULLSTRING;
         else
             nullString = inNullString;
+        if (null == inComment)
+            comment = DEFAULT_COMMENT_STRING.charAt(0);
+        else
+            comment = inComment.charAt(0);
         charsPerColumn = inCharsPerColumn;
         delim = ("\\t".equals(delimiter)) ?  '\t' : delimiter.charAt(0);
         quote = '\"';

--- a/src/main/java/com/datastax/loader/parser/DelimParser.java
+++ b/src/main/java/com/datastax/loader/parser/DelimParser.java
@@ -80,6 +80,7 @@ public class DelimParser {
 	settings.getFormat().setDelimiter(delim);
 	settings.getFormat().setQuote(quote);
 	settings.getFormat().setQuoteEscape(escape);
+	settings.getFormat().setComment('\0');
 	
 	csvp = new CsvParser(settings);
     }


### PR DESCRIPTION
Unable to load data that starts with #.

Better not to consider parser's default comment symbol as comment symbol.
