### PR TITLE
Support empty strings with alternative null strings and support cassandra hex strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,16 @@
+!.gitignore
+
+out/
 build/
+gradle/
 .gradle/
+.idea/
 *~
 *.jar
 cassandra-loader
 *.BADINSERT
 *.BADPARSE
 *.LOG
+*.iml
+/gradlew
+/gradlew.bat

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'application'
 
-def versionNum = '0.0.27'
+def versionNum = '0.0.28'
 
 allprojects {
     tasks.withType(JavaCompile) {

--- a/src/main/java/com/datastax/loader/CqlDelimLoadTask.java
+++ b/src/main/java/com/datastax/loader/CqlDelimLoadTask.java
@@ -25,6 +25,7 @@ import com.datastax.loader.futures.FutureManager;
 import com.datastax.loader.futures.PrintingFutureSet;
 import com.datastax.loader.futures.JsonPrintingFutureSet;
 import com.datastax.loader.parser.BooleanParser;
+import com.datastax.loader.parser.ByteBufferParser;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -84,6 +85,7 @@ class CqlDelimLoadTask implements Callable<Long> {
     private String cqlSchema;
     private Locale locale = null;
     private BooleanParser.BoolStyle boolStyle = null;
+    private ByteBufferParser.BlobFormat blobFormat = null;
     private String dateFormatString = null;
     private String localDateFormatString = null;
     private String nullString = null;
@@ -105,7 +107,8 @@ class CqlDelimLoadTask implements Callable<Long> {
                             int inCharsPerColumn,
                             String inNullString, String inCommentString, 
                             String inDateFormatString, String inLocalDateFormatString,
-                            BooleanParser.BoolStyle inBoolStyle, 
+                            BooleanParser.BoolStyle inBoolStyle,
+                            ByteBufferParser.BlobFormat inBlobFormat,
                             Locale inLocale, 
                             long inMaxErrors, long inSkipRows, 
                             String inSkipCols, long inMaxRows,
@@ -125,6 +128,7 @@ class CqlDelimLoadTask implements Callable<Long> {
         dateFormatString = inDateFormatString;
         localDateFormatString = inLocalDateFormatString;
         boolStyle = inBoolStyle;
+        blobFormat = inBlobFormat;
         locale = inLocale;
         maxErrors = inMaxErrors;
         skipRows = inSkipRows;
@@ -189,16 +193,18 @@ class CqlDelimLoadTask implements Callable<Long> {
             cdp = new CqlDelimParser(cqlSchema, delimiter, charsPerColumn, 
                                      nullString, commentString,
                                      dateFormatString, localDateFormatString,
-                                     boolStyle, locale,
-                                     skipCols, session, true, ttl);
+                                     boolStyle, blobFormat,
+                                     locale, skipCols,
+                                     session, true, ttl);
         }
         else if (format.equalsIgnoreCase("jsonline")
                  || format.equalsIgnoreCase("jsonarray")) {
             cdp = new CqlDelimParser(keyspace, table, delimiter, charsPerColumn,
                                      nullString, commentString,
                                      dateFormatString, localDateFormatString,
-                                     boolStyle, locale, 
-                                     skipCols, session, true, ttl);
+                                     boolStyle, blobFormat,
+                                     locale, skipCols,
+                                     session, true, ttl);
         }
 
         insert = cdp.generateInsert();

--- a/src/main/java/com/datastax/loader/CqlDelimParser.java
+++ b/src/main/java/com/datastax/loader/CqlDelimParser.java
@@ -50,8 +50,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -72,13 +70,15 @@ public class CqlDelimParser {
     public CqlDelimParser(String inCqlSchema, String inDelimiter, int inCharsPerColumn,
                           String inNullString, String inCommentString, 
                           String inDateFormatString, String inLocalDateFormatString,
-                          BooleanParser.BoolStyle inBoolStyle, Locale inLocale,
-                          String skipList, Session session, boolean bLoader, int inTtl) 
+                          BooleanParser.BoolStyle inBoolStyle, ByteBufferParser.BlobFormat inBlobFormat,
+                          Locale inLocale, String skipList,
+                          Session session, boolean bLoader, int inTtl)
         throws ParseException {
         // Optionally provide things for the line parser - date format, boolean format, locale
 	ttl = inTtl;
-        initPmap(inDateFormatString, inLocalDateFormatString, inBoolStyle, 
-                 inLocale, bLoader);
+        initPmap(inDateFormatString, inLocalDateFormatString,
+                inBoolStyle, inBlobFormat,
+                inLocale, bLoader);
         processCqlSchema(inCqlSchema, session);
         createDelimParser(inDelimiter, inCharsPerColumn, inNullString, inCommentString, skipList);
     }   
@@ -87,15 +87,17 @@ public class CqlDelimParser {
                           int inCharsPerColumn,
                           String inNullString, String inCommentString, 
                           String inDateFormatString, String inLocalDateFormatString,
-                          BooleanParser.BoolStyle inBoolStyle, Locale inLocale,
-                          String skipList, Session session, boolean bLoader, int inTtl) 
+                          BooleanParser.BoolStyle inBoolStyle, ByteBufferParser.BlobFormat inBlobFormat,
+                          Locale inLocale, String skipList,
+                          Session session, boolean bLoader, int inTtl)
         throws ParseException {
         // Optionally provide things for the line parser - date format, boolean format, locale
 	ttl = inTtl;
         keyspace = inKeyspace;
         tablename = inTable;
-        initPmap(inDateFormatString, inLocalDateFormatString, inBoolStyle, 
-                 inLocale, bLoader);
+        initPmap(inDateFormatString, inLocalDateFormatString,
+                inBoolStyle, inBlobFormat,
+                inLocale, bLoader);
         processCqlSchema(session);
         createDelimParser(inDelimiter, inCharsPerColumn, inNullString, inCommentString,  skipList);
     }
@@ -117,7 +119,8 @@ public class CqlDelimParser {
 
     // intialize the Parsers and the parser map
     private void initPmap(String dateFormatString, String localDateFormatString,
-                          BooleanParser.BoolStyle inBoolStyle, 
+                          BooleanParser.BoolStyle inBoolStyle,
+                          ByteBufferParser.BlobFormat inBlobFormat,
                           Locale inLocale, boolean bLoader) {
         pmap = new HashMap<DataType.Name, Parser>();
         Parser byteParser = new ByteParser(inLocale, bLoader);
@@ -131,7 +134,7 @@ public class CqlDelimParser {
         Parser uuidParser = new UUIDParser();
         Parser bigDecimalParser = new BigDecimalParser();
         Parser bigIntegerParser = new BigIntegerParser();
-        Parser byteBufferParser = new ByteBufferParser();
+        Parser byteBufferParser = new ByteBufferParser(inBlobFormat);
         Parser inetAddressParser = new InetAddressParser();
         Parser dateParser = new DateParser(dateFormatString);
         Parser localDateParser = new LocalDateParser(localDateFormatString);

--- a/src/main/java/com/datastax/loader/parser/ByteBufferParser.java
+++ b/src/main/java/com/datastax/loader/parser/ByteBufferParser.java
@@ -17,20 +17,71 @@ package com.datastax.loader.parser;
 
 import java.nio.ByteBuffer;
 import javax.xml.bind.DatatypeConverter;
-import com.datastax.driver.core.Row;
-import com.datastax.driver.core.exceptions.InvalidTypeException;
+import com.datastax.driver.core.utils.Bytes;
 
 // ByteBuffer parser
 public class ByteBufferParser extends AbstractParser {
+    public static enum BlobFormat {
+        Base64("base64"),
+        HexString("hex");
+
+        private String formatStr;
+
+        BlobFormat(String inFormatStr) {
+            formatStr = inFormatStr;
+        }
+
+        public String getFormat() {
+            return formatStr;
+        }
+    }
+
+    public static BlobFormat getBlobFormat(String instr) {
+        for (BlobFormat bs : BlobFormat.values()) {
+            if (bs.getFormat().equalsIgnoreCase(instr)) {
+                return bs;
+            }
+        }
+        return null;
+    }
+
+    public static String getOptions() {
+        String ret = "'" + BlobFormat.Base64.getFormat() + "'";
+        ret = ret + ", '" + BlobFormat.HexString.getFormat() + "'";
+        return ret;
+    }
+
+    private BlobFormat format;
+
+    public ByteBufferParser(BlobFormat inFormat) {
+        if (null == inFormat)
+            inFormat = BlobFormat.Base64;
+        this.format = inFormat;
+    }
+
     public ByteBuffer parseIt(String toparse) {
         if (null == toparse)
             return null;
-        byte[] barry = DatatypeConverter.parseBase64Binary(toparse);
-        return ByteBuffer.wrap(barry);
+
+        switch (format) {
+            case HexString:
+                ByteBuffer bb = Bytes.fromHexString(toparse);
+                return bb;
+
+            default:
+                byte[] barry = DatatypeConverter.parseBase64Binary(toparse);
+                return ByteBuffer.wrap(barry);
+        }
     }
 
     public String format(Object o) {
         ByteBuffer v = (ByteBuffer)o;
-        return DatatypeConverter.printBase64Binary(v.array());
+        switch (format) {
+            case HexString:
+                return Bytes.toHexString(v);
+
+            default:
+                return DatatypeConverter.printBase64Binary(v.array());
+        }
     }
 }

--- a/src/main/java/com/datastax/loader/parser/DelimParser.java
+++ b/src/main/java/com/datastax/loader/parser/DelimParser.java
@@ -86,6 +86,7 @@ public class DelimParser {
         settings.setKeepQuotes(true);
         settings.setKeepEscapeSequences(true);
         settings.getFormat().setComment(comment);
+        settings.setNullValue(DEFAULT_NULLSTRING);
 
         csvp = new CsvParser(settings);
     }


### PR DESCRIPTION
This enables better support for importing CSVs generated by `COPY` from cqlsh. It can load/unload cassandra hex strings and import empty strings while using alternative null strings.