### PR TITLE
Fix CqlDelimLoad to return false if a future result is 0

### DIFF
--- a/src/main/java/com/datastax/loader/CqlDelimLoad.java
+++ b/src/main/java/com/datastax/loader/CqlDelimLoad.java
@@ -685,8 +685,13 @@ public class CqlDelimLoad {
                 results.add(executor.submit(worker));
             }
             executor.shutdown();
-            for (Future<Long> res : results)
+            for (Future<Long> res : results){
+                if (res.get() <= 0) {
+                    cleanup();
+                    return false;
+                }
                 total += res.get();
+            }
         }
 
         // Cleanup


### PR DESCRIPTION
The future result will be 0 when there is a fatal error.  Instead of
adding the 0 to the total rows loaded, return false which will cause
cassandra-loader to exit non-0 indicating a fatal error occurred.