### PR TITLE
Enable TIME formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ cassandra-loader -f myFileToLoad.csv -host 1.2.3.4 -schema "test.ltest(a, b, c, 
  `-boolStyle`     | Boolean Style      | TRUE_FALSE                 | String for boolean values.  Options are "1_0", "Y_N", "T_F", "YES_NO", "TRUE_FALSE".
  `-decimalDelim`  | Decimal delimiter  | .                          | Delimiter for decimal values.  Options are "." or ","
  `-dateFormat`    | Date Format String | default for Locale.ENGLISH | Date format string as specified in the SimpleDateFormat Java class: http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html
+ `-localTimeFormat`| Time Format String| long                       | Time format string may be "long" (nanoseconds since midnight), "iso" (ISO_LOCAL_TIME predefined format) or a format string as specified in: https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html  
  `-skipRows`      | Rows to skip       | 0                          | Number of rows to skip at the beginning of the file
  `-skipCols`      | Columns to skip    | &lt;not set&gt;                  | Comma-separated list of columns to skip loading (0-counted)
  `-maxRows`       | Max rows to read   | -1                         | Maximum rows to read (after optional skipping of rows).  -1 signifies all rows.
@@ -202,6 +203,7 @@ OPTIONS:
   -charsPerColumn <chars>            Max number of chars per column [4096]
   -dateFormat <dateFormatString>     Date format for TIMESTAMP [default for Locale.ENGLISH]
   -localDateFormat <formatString>    Date format for DATE [yyyy-MM-dd]
+  -localTimeFormat [long|iso|<fmt>]  Time format for TIME [long]
   -nullString <nullString>           String that signifies NULL [none]
   -comment <commentString>           Comment symbol to use [none]
   -skipRows <skipRows>               Number of rows to skip [0]
@@ -340,6 +342,7 @@ OPTIONS:
   -delim <delimiter>                 Delimiter to use [,]
   -dateFormat <dateFormatString>     Date format for TIMESTAMP [default for Locale.ENGLISH]
   -localDateFormat <FormatString>    Date format for DATE [yyyy-MM-dd]
+  -localTimeFormat [long|iso|<fmt>]  Time format for TIME [long]
   -nullString <nullString>           String that signifies NULL [none]
   -port <portNumber>                 CQL Port Number [9042]
   -user <username>                   Cassandra username [none]

--- a/src/main/java/com/datastax/loader/CqlDelimLoad.java
+++ b/src/main/java/com/datastax/loader/CqlDelimLoad.java
@@ -129,6 +129,8 @@ public class CqlDelimLoad {
     private BooleanParser.BoolStyle boolStyle = null;
     private String dateFormatString = null;
     private String localDateFormatString = "yyyy-MM-dd";
+    private boolean localTimeAsLong = true;
+    private String localTimeFormatString = null;
     private String nullString = null;
     private String commentString = null;
     private String delimiter = null;
@@ -150,6 +152,7 @@ public class CqlDelimLoad {
         usage.append("  -charsPerColumn <chars>            Max number of chars per column [4096]\n");
         usage.append("  -dateFormat <dateFormatString>     Date format for TIMESTAMP [default for Locale.ENGLISH]\n");
         usage.append("  -localDateFormat <formatString>    Date format for DATE [yyyy-MM-dd]\n");
+        usage.append("  -localTimeFormat [long|iso|<fmt>]  Time format for TIME [long]\n");
         usage.append("  -nullString <nullString>           String that signifies NULL [none]\n");
         usage.append("  -comment <commentString>           Comment symbol to use [none]\n");
         usage.append("  -skipRows <skipRows>               Number of rows to skip [0]\n");
@@ -427,6 +430,18 @@ public class CqlDelimLoad {
         if (null != (tkey = amap.remove("-badDir")))        badDir = tkey;
         if (null != (tkey = amap.remove("-dateFormat")))    dateFormatString = tkey;
         if (null != (tkey = amap.remove("-localDateFormat")))    localDateFormatString = tkey;
+        if (null != (tkey = amap.remove("-localTimeFormat"))) {
+            if (tkey.equals("long")) {
+                localTimeAsLong = true;
+                localTimeFormatString = null;
+            } else if (tkey.equals("iso")) {
+                localTimeAsLong = false;
+                localTimeFormatString = null;
+            } else {
+                localTimeAsLong = false;
+                localTimeFormatString = tkey;
+            }
+        }
         if (null != (tkey = amap.remove("-nullString")))    nullString = tkey;
         if (null != (tkey = amap.remove("-comment")))       commentString = tkey;
         if (null != (tkey = amap.remove("-delim")))         delimiter = tkey;
@@ -643,8 +658,9 @@ public class CqlDelimLoad {
                                                          charsPerColumn, nullString,
                                                          commentString,
                                                          dateFormatString, 
-                                                         localDateFormatString, 
-                                                         boolStyle, locale, 
+                                                         localDateFormatString,
+                                                         localTimeAsLong, localTimeFormatString,
+                                                         boolStyle, locale,
                                                          maxErrors, skipRows,
                                                          skipCols,
                                                          maxRows, badDir, infile, 
@@ -668,7 +684,8 @@ public class CqlDelimLoad {
                                                              charsPerColumn, nullString,
                                                              commentString,
                                                              dateFormatString, 
-                                                             localDateFormatString, 
+                                                             localDateFormatString,
+                                                             localTimeAsLong, localTimeFormatString,
                                                              boolStyle, locale, 
                                                              maxErrors, skipRows,
                                                              skipCols,

--- a/src/main/java/com/datastax/loader/CqlDelimLoadTask.java
+++ b/src/main/java/com/datastax/loader/CqlDelimLoadTask.java
@@ -86,6 +86,8 @@ class CqlDelimLoadTask implements Callable<Long> {
     private BooleanParser.BoolStyle boolStyle = null;
     private String dateFormatString = null;
     private String localDateFormatString = null;
+    private boolean localTimeAsLong = true;
+    private String localTimeFormatString = null;
     private String nullString = null;
     private String commentString = null;
     private String delimiter = null;
@@ -105,6 +107,7 @@ class CqlDelimLoadTask implements Callable<Long> {
                             int inCharsPerColumn,
                             String inNullString, String inCommentString, 
                             String inDateFormatString, String inLocalDateFormatString,
+                            boolean inLocalTimeAsLong, String inLocalTimeFormatString,
                             BooleanParser.BoolStyle inBoolStyle, 
                             Locale inLocale, 
                             long inMaxErrors, long inSkipRows, 
@@ -124,6 +127,8 @@ class CqlDelimLoadTask implements Callable<Long> {
         commentString = inCommentString;
         dateFormatString = inDateFormatString;
         localDateFormatString = inLocalDateFormatString;
+        localTimeAsLong = inLocalTimeAsLong;
+        localTimeFormatString = inLocalTimeFormatString;
         boolStyle = inBoolStyle;
         locale = inLocale;
         maxErrors = inMaxErrors;
@@ -189,6 +194,7 @@ class CqlDelimLoadTask implements Callable<Long> {
             cdp = new CqlDelimParser(cqlSchema, delimiter, charsPerColumn, 
                                      nullString, commentString,
                                      dateFormatString, localDateFormatString,
+                                     localTimeAsLong, localTimeFormatString,
                                      boolStyle, locale,
                                      skipCols, session, true, ttl);
         }
@@ -197,6 +203,7 @@ class CqlDelimLoadTask implements Callable<Long> {
             cdp = new CqlDelimParser(keyspace, table, delimiter, charsPerColumn,
                                      nullString, commentString,
                                      dateFormatString, localDateFormatString,
+                                     localTimeAsLong, localTimeFormatString,
                                      boolStyle, locale, 
                                      skipCols, session, true, ttl);
         }

--- a/src/main/java/com/datastax/loader/parser/LocalTimeParser.java
+++ b/src/main/java/com/datastax/loader/parser/LocalTimeParser.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Carl Livermore
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.loader.parser;
+
+import java.text.ParseException;
+import java.time.format.DateTimeFormatter;
+import java.time.LocalTime;
+
+// Time parser - takes a format string
+public class LocalTimeParser extends AbstractParser {
+    private DateTimeFormatter dateTimeFormatter;
+
+    public LocalTimeParser(String inFormatString) {
+        if (null == inFormatString)
+            dateTimeFormatter = DateTimeFormatter.ISO_LOCAL_TIME;
+        else
+            dateTimeFormatter = DateTimeFormatter.ofPattern(inFormatString);
+    }
+
+    public Long parseIt(String toparse) throws ParseException {
+        if (null == toparse)
+            return null;
+
+        try {
+            return LocalTime.parse(toparse, dateTimeFormatter).toNanoOfDay();
+        } catch (Exception e) {
+            throw new ParseException(e.getMessage(), 0);
+        }
+    }
+
+    public String format(Object o) {
+        LocalTime v = LocalTime.ofNanoOfDay((Long)o);
+        return v.format(dateTimeFormatter);
+    }
+}


### PR DESCRIPTION
I found that columns of type TIME are expected to be a long when loaded. This PR adds an option, -localTimeFormat, that allows columns to type TIME to formatted E.g. HH:mm:ss.SS.

I submitted a PR to fix the issue: #101