### PR TITLE
Add support for named pipes - relax restrictions on -f argument to just be readable

### DIFF
--- a/src/main/java/com/datastax/loader/CqlDelimLoad.java
+++ b/src/main/java/com/datastax/loader/CqlDelimLoad.java
@@ -262,8 +262,13 @@ public class CqlDelimLoad {
         }
         if (!STDIN.equalsIgnoreCase(filename)) {
             File infile = new File(filename);
-            if ((!infile.isFile()) && (!infile.isDirectory())) {
-                System.err.println("The -f argument needs to be a file or a directory");
+            // Support for named pipes - Support -f as long as readable
+            // if ((!infile.isFile()) && (!infile.isDirectory())) {
+            //     System.err.println("The -f argument needs to be a file or a directory");
+            //     return false;
+            // }
+            if (!infile.canRead()) {
+                System.err.println("The -f argument needs to be readable");
                 return false;
             }
             if (infile.isDirectory()) {
@@ -615,9 +620,11 @@ public class CqlDelimLoad {
         }
         else {
             infile = new File(filename);
-            if (infile.isFile()) {
-            }
-            else {
+            // Support for named pipes - Do directory stuff only if file is a directory
+            // if (infile.isFile()) {
+            // }
+            // else {
+            if (infile.isDirectory()) {
                 inFileList = infile.listFiles();
                 if (inFileList.length < 1)
                     throw new IOException("directory is empty");

--- a/src/main/java/com/datastax/loader/CqlDelimLoadTask.java
+++ b/src/main/java/com/datastax/loader/CqlDelimLoadTask.java
@@ -159,6 +159,12 @@ class CqlDelimLoadTask implements Callable<Long> {
             reader = new BufferedReader(new InputStreamReader(System.in));
             readerName = "stdin";
         }
+        // Support for named pipes - must not be gzipped - like stdin
+        else if (!infile.isFile()) {
+            InputStream is = new FileInputStream(infile);
+            reader = new BufferedReader(new InputStreamReader(is));
+            readerName = infile.getName();
+        }
         else {
             InputStream is =  null;
             try {


### PR DESCRIPTION
Added support for named pipes by removing restrictions that -f argument must be a stdin, a file or a directory as long as it is readable. If the -f argument is not a file or directory, it must not be gzipped. This was always the case for stdin so this is consistent. 